### PR TITLE
map* and fromList*

### DIFF
--- a/src/Data/Map/NonEmpty.hs
+++ b/src/Data/Map/NonEmpty.hs
@@ -153,7 +153,7 @@ fromListWith :: Ord k => (a -> a -> a) -> [(k, a)] -> Maybe (NonEmptyMap k a)
 fromListWith f xs = fromListWithKey (\_ x y -> f x y) xs
 
 fromNonEmptyWithKey :: Ord k => (k -> a -> a -> a) -> NonEmpty (k, a) -> NonEmptyMap k a
-fromNonEmptyWithKey f ((xk, xv) :| xs) = foldlStrict ins (NonEmptyMap (xk, xv) Map.empty) xs
+fromNonEmptyWithKey f (x :| xs) = foldlStrict ins (NonEmptyMap x Map.empty) xs
   where
     ins t (k, v) = insertWithKey f k v t
 

--- a/src/Data/Map/NonEmpty.hs
+++ b/src/Data/Map/NonEmpty.hs
@@ -48,6 +48,11 @@ module Data.Map.NonEmpty(
   , toList -- :: NonEmptyMap k a -> [(k, a)]
   , Data.Map.NonEmpty.toNonEmpty -- :: NonEmptyMap k a -> NonEmpty (k, a)
   , toMap -- :: Ord k => NonEmptyMap k a -> Map.Map k a
+  -- * Map
+  , Data.Map.NonEmpty.map
+  , mapWithKey
+  , mapKeys
+  , mapKeysWith
 ) where
 
 import qualified Data.Map                   as Map

--- a/src/Data/Map/NonEmpty.hs
+++ b/src/Data/Map/NonEmpty.hs
@@ -49,10 +49,10 @@ module Data.Map.NonEmpty(
   , Data.Map.NonEmpty.toNonEmpty -- :: NonEmptyMap k a -> NonEmpty (k, a)
   , toMap -- :: Ord k => NonEmptyMap k a -> Map.Map k a
   -- * Map
-  , Data.Map.NonEmpty.map
-  , mapWithKey
-  , mapKeys
-  , mapKeysWith
+  , Data.Map.NonEmpty.map -- :: (t -> b) -> NonEmptyMap k t -> NonEmptyMap k b
+  , mapWithKey -- :: (t -> b) -> NonEmptyMap k t -> NonEmptyMap k b
+  , mapKeys -- :: Ord k => (t2 -> k) -> NonEmptyMap t2 t1 -> NonEmptyMap k t1
+  , mapKeysWith -- Ord k => (t1 -> t1 -> t1) -> (t2 -> k) -> NonEmptyMap t2 t1 -> NonEmptyMap k t1
 ) where
 
 import qualified Data.Map                   as Map

--- a/src/Data/Map/NonEmpty.hs
+++ b/src/Data/Map/NonEmpty.hs
@@ -32,7 +32,7 @@ module Data.Map.NonEmpty(
   , insertLookupWithKey -- :: Ord k => (k -> a -> a -> a) -> k -> a -> NonEmptyMap k a -> (Maybe a, NonEmptyMap k a)
   -- * Deletion/Update
   , delete -- :: Ord k => k -> NonEmptyMap k a -> Map.Map k a
-  , adjust -- :: Ord k => (a -> a) -> k -> NonEmptyMap k a -> NonEmptyMap k a 
+  , adjust -- :: Ord k => (a -> a) -> k -> NonEmptyMap k a -> NonEmptyMap k a
   , update -- :: Ord k => (a -> Maybe a) -> k -> NonEmptyMap k a -> Map.Map k a
   , alter  -- :: Ord k => (Maybe a -> Maybe a) -> k -> NonEmptyMap k a -> Map.Map k a
   , alterF -- :: forall f k a. (Functor f, Ord k) => (Maybe a -> f (Maybe a)) -> k -> NonEmptyMap k a -> f (Map.Map k a)
@@ -42,7 +42,7 @@ module Data.Map.NonEmpty(
   , findWithDefault -- :: Ord k => a -> k -> NonEmptyMap k a -> a
   , member -- :: Ord k => k -> NonEmptyMap k a -> Bool
   , notMember -- :: Ord k => k -> NonEmptyMap k a -> Bool
-  -- * Size 
+  -- * Size
   , size -- :: NonEmptyMap k a -> In
   -- * Conversions
   , toList -- :: NonEmptyMap k a -> [(k, a)]
@@ -125,7 +125,7 @@ instance Foldable (NonEmptyMap k) where
 instance Foldable1 (NonEmptyMap k) where
   foldMap1 :: Semigroup m => (a -> m) -> NonEmptyMap k a -> m
   foldMap1 f (NonEmptyMap (k, a) m) = Map.foldr ((<>) . f) (f a) m
-  
+
 -- Construction
 singleton :: (k, a) -> NonEmptyMap k a
 singleton tup = NonEmptyMap tup Map.empty
@@ -149,12 +149,12 @@ insertWith f key value (NonEmptyMap (k, a) m) | key == k  = NonEmptyMap (key, f 
 insertWith f key value (NonEmptyMap (k, a) m)             = NonEmptyMap (k, a) (Map.insertWith f key value m)
 
 insertWithKey :: Ord k => (k -> a -> a -> a) -> k -> a -> NonEmptyMap k a -> NonEmptyMap k a
-insertWithKey f key value (NonEmptyMap (k, a) m) = 
+insertWithKey f key value (NonEmptyMap (k, a) m) =
   if k == key then NonEmptyMap (key, f key value a) m
   else NonEmptyMap (k, a) (Map.insertWithKey f key value m)
 
 insertLookupWithKey :: Ord k => (k -> a -> a -> a) -> k -> a -> NonEmptyMap k a -> (Maybe a, NonEmptyMap k a)
-insertLookupWithKey f key value (NonEmptyMap (k, a) m) = 
+insertLookupWithKey f key value (NonEmptyMap (k, a) m) =
   if k == key then (Just a, NonEmptyMap(key, f key value a) m)
   else fmap (NonEmptyMap (k, a)) (Map.insertLookupWithKey f key value m)
 
@@ -165,7 +165,7 @@ delete :: Ord k => k -> NonEmptyMap k a -> Map.Map k a
 delete key (NonEmptyMap (k, a) m) | key == k  = m
 delete key (NonEmptyMap (k, a) m)             = Map.insert k a (Map.delete k m)
 
-adjust :: Ord k => (a -> a) -> k -> NonEmptyMap k a -> NonEmptyMap k a 
+adjust :: Ord k => (a -> a) -> k -> NonEmptyMap k a -> NonEmptyMap k a
 adjust f key (NonEmptyMap (k, a) m) | key == k  = NonEmptyMap (key, f a) m
 adjust f key (NonEmptyMap (k, a) m)             = NonEmptyMap (k, a) (Map.adjust f key m)
 
@@ -181,7 +181,7 @@ alter f key (NonEmptyMap (k, a) m) | key == k = case f (Just a) of
   Nothing -> m
 alter f key (NonEmptyMap (k, a) m)            = Map.insert k a (Map.alter f key m)
 
-alterF :: forall f k a. (Functor f, Ord k) => (Maybe a -> f (Maybe a)) -> k -> NonEmptyMap k a -> f (Map.Map k a) 
+alterF :: forall f k a. (Functor f, Ord k) => (Maybe a -> f (Maybe a)) -> k -> NonEmptyMap k a -> f (Map.Map k a)
 alterF f key (NonEmptyMap (k, a) m) | key == k = insideF <$> f (Just a)
   where
     insideF :: Maybe a -> Map.Map k a
@@ -213,7 +213,7 @@ notMember k nem = not $ member k nem
   Size
 --------------------------------------------------------------------}
 size :: NonEmptyMap k a -> Int
-size (NonEmptyMap _ m) = 1 + Map.size m   
+size (NonEmptyMap _ m) = 1 + Map.size m
 
 {--------------------------------------------------------------------
   Conversions
@@ -228,3 +228,14 @@ toNonEmpty (NonEmptyMap tup m) = tup :| Map.toList m
 
 toMap :: Ord k => NonEmptyMap k a -> Map.Map k a
 toMap (NonEmptyMap (k, a) m) = Map.insert k a m
+
+
+{--------------------------------------------------------------------
+  Map
+--------------------------------------------------------------------}
+
+mapWithKey :: (t -> b) -> NonEmptyMap k t -> NonEmptyMap k b
+mapWithKey f (NonEmptyMap (k, v) map) =  NonEmptyMap (k, f v) (Map.map f map)
+
+map :: (t -> b) -> NonEmptyMap k t -> NonEmptyMap k b
+map = mapWithKey

--- a/src/Data/Map/NonEmpty.hs
+++ b/src/Data/Map/NonEmpty.hs
@@ -239,3 +239,6 @@ mapWithKey f (NonEmptyMap (k, v) map) =  NonEmptyMap (k, f v) (Map.map f map)
 
 map :: (t -> b) -> NonEmptyMap k t -> NonEmptyMap k b
 map = mapWithKey
+
+mapKeys :: Ord t2 => (t -> t2) -> NonEmptyMap t a -> NonEmptyMap t2 a
+mapKeys f (NonEmptyMap (k, v) map) = NonEmptyMap (f k, v) (Map.mapKeys f map)

--- a/src/Data/Map/NonEmpty.hs
+++ b/src/Data/Map/NonEmpty.hs
@@ -49,7 +49,7 @@ module Data.Map.NonEmpty(
   , Data.Map.NonEmpty.toNonEmpty -- :: NonEmptyMap k a -> NonEmpty (k, a)
   , toMap -- :: Ord k => NonEmptyMap k a -> Map.Map k a
   -- * Map
-  , Data.Map.NonEmpty.map -- :: (t -> b) -> NonEmptyMap k t -> NonEmptyMap k b
+  , map -- :: (t -> b) -> NonEmptyMap k t -> NonEmptyMap k b
   , mapWithKey -- :: (t -> b) -> NonEmptyMap k t -> NonEmptyMap k b
   , mapKeys -- :: Ord k => (t2 -> k) -> NonEmptyMap t2 t1 -> NonEmptyMap k t1
   , mapKeysWith -- Ord k => (t1 -> t1 -> t1) -> (t2 -> k) -> NonEmptyMap t2 t1 -> NonEmptyMap k t1
@@ -67,7 +67,7 @@ import Data.List.NonEmpty                    (NonEmpty(..))
 import qualified Data.List.NonEmpty         as NonEmptyList
 import qualified Data.List                  as List
 
-import Prelude                              hiding (lookup)
+import Prelude                              hiding (lookup, map)
 
 
 -- | A NonEmptyMap of keys k to values a

--- a/src/Data/Map/NonEmpty.hs
+++ b/src/Data/Map/NonEmpty.hs
@@ -24,7 +24,11 @@ module Data.Map.NonEmpty(
   -- * Construction
   , singleton -- :: (k, a) -> NonEmptyMap k v
   , fromList -- :: Ord k => [(k, a)] -> Maybe (NonEmptyMap k a)
+  , fromListWith -- :: Ord k => (a -> a -> a) -> [(k, a)] -> Maybe (NonEmptyMap k a)
+  , fromListWithKey -- :: Ord k => (k -> a -> a -> a) -> [(k, a)] -> Maybe (NonEmptyMap k a)
   , fromNonEmpty -- :: Ord k => NonEmpty (k, a) -> NonEmptyMap k a
+  , fromNonEmptyWith -- :: Ord k => (t -> t -> t) -> NonEmpty (k, t) -> NonEmptyMap k t
+  , fromNonEmptyWithKey -- :: Ord k => (k -> a -> a -> a) -> NonEmpty (k, a) -> NonEmptyMap k a
   -- * Insertion
   , insert -- :: Ord k => k -> a -> NonEmptyMap k a -> NonEmptyMap k a
   , insertWith -- :: Ord k => (a -> a -> a) -> k -> a -> NonEmptyMap k a -> NonEmptyMap k a
@@ -52,7 +56,7 @@ module Data.Map.NonEmpty(
   , map -- :: (t -> b) -> NonEmptyMap k t -> NonEmptyMap k b
   , mapWithKey -- :: (t -> b) -> NonEmptyMap k t -> NonEmptyMap k b
   , mapKeys -- :: Ord k => (t2 -> k) -> NonEmptyMap t2 t1 -> NonEmptyMap k t1
-  , mapKeysWith -- Ord k => (t1 -> t1 -> t1) -> (t2 -> k) -> NonEmptyMap t2 t1 -> NonEmptyMap k t1
+  , mapKeysWith -- :: Ord k => (t1 -> t1 -> t1) -> (t2 -> k) -> NonEmptyMap t2 t1 -> NonEmptyMap k t1
 ) where
 
 import qualified Data.Map                   as Map


### PR DESCRIPTION
This is my humble contribution, for the moment... 😄 

**Functions added:**
```haskell

-- Exported
map :: (t -> b) -> NonEmptyMap k t -> NonEmptyMap k b
mapWithKey :: (t -> b) -> NonEmptyMap k t -> NonEmptyMap k b
mapKeys :: Ord k => (t2 -> k) -> NonEmptyMap t2 t1 -> NonEmptyMap k t1
mapKeysWith :: Ord k => (t1 -> t1 -> t1) -> (t2 -> k) -> NonEmptyMap t2 t1 -> NonEmptyMap k t1
fromListWithKey :: Ord k => (k -> a -> a -> a) -> [(k, a)] -> Maybe (NonEmptyMap k a)
fromListWith :: Ord k => (a -> a -> a) -> [(k, a)] -> Maybe (NonEmptyMap k a)
fromNonEmptyWithKey :: Ord k => (k -> a -> a -> a) -> NonEmpty (k, a) -> NonEmptyMap k a
fromNonEmptyWith :: Ord k => (t -> t -> t) -> NonEmpty (k, t) -> NonEmptyMap k t


-- Utils
foldlStrict :: (a -> b -> a) -> a -> [b] -> a
```